### PR TITLE
fix: resourceName with empty item can lead to list resources

### DIFF
--- a/lib/list_secrets.rego
+++ b/lib/list_secrets.rego
@@ -15,4 +15,12 @@ evaluateRoles(roles, owner) {
   pb.valueOrWildcard(rule.resources, "secrets")
   pb.valueOrWildcard(rule.verbs, "list")
   pb.valueOrWildcard(rule.apiGroups, "")
+  resourceNamesNotExistOrContainEmptyItem(rule)
 } 
+
+resourceNamesNotExistOrContainEmptyItem(rule) {
+  not pb.hasKey(rule, "resourceNames")
+} {
+  pb.hasKey(rule, "resourceNames")
+  "" in rule.resourceNames
+}

--- a/lib/list_secrets.rego
+++ b/lib/list_secrets.rego
@@ -4,7 +4,7 @@ import future.keywords.in
 
 describe[{"desc": desc, "severity": severity}] {
   desc := "Identities that can list secrets cluster-wide may access confidential information, and in some cases serviceAccount tokens"
-  severity := "Medium"
+  severity := "Critical"
 }
 targets := {"serviceAccounts", "nodes", "users", "groups"}
 

--- a/lib/retrieve_token_secrets.rego
+++ b/lib/retrieve_token_secrets.rego
@@ -13,8 +13,16 @@ evaluateRoles(roles, owner) {
   some role in roles
   pb.affectsPrivNS(role)
   some rule in role.rules
-  pb.valueOrWildcard(rule.resources, "secrets")
-  pb.getOrListOrWildcard(rule.verbs) # get -> bruteforcing token secrets names
   pb.valueOrWildcard(rule.apiGroups, "")
-  not pb.hasKey(rule, "resourceNames")
+  pb.valueOrWildcard(rule.resources, "secrets")
+  canBruteOrListSecrets(rule)
 } 
+
+canBruteOrListSecrets(rule) {
+  pb.getOrListOrWildcard(rule.verbs) # get -> bruteforcing token secrets names
+  not pb.hasKey(rule, "resourceNames")
+} {
+  pb.valueOrWildcard(rule.verbs, "list")
+  pb.hasKey(rule, "resourceNames") # '' resourceName can also lead to list resources
+  "" in rule.resourceNames
+}


### PR DESCRIPTION
I have discovered a corner case that can bypass the detection of listing secret resources. This patch fixes the missed detection.

```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: ttt
rules:
- apiGroups:
  - ''
  resources:
  - secrets
  verbs:
  - 'list'
  resourceNames:
  - aaa
  - ""
```